### PR TITLE
Adjust GB message width scaling

### DIFF
--- a/PicoPad/EMU/GBC/src/emu_gb_msg.c
+++ b/PicoPad/EMU/GBC/src/emu_gb_msg.c
@@ -16,7 +16,7 @@
 
 #include "../include.h"
 
-#define EMU_LCD_WIDTH	320	// LCD display width
+#define EMU_LCD_WIDTH   WIDTH	// LCD display width
 #define EMU_LCD_HEIGHT	HEIGHT	// LCD display height
 
 // text screen buffer (only characters; 160 bytes)
@@ -126,14 +126,16 @@ void GB_TextPrintCenter(const char* txt)
 // update text screen on display
 void GB_TextUpdate()
 {
-	u8 ch;
-	int line, col, pix;
-	u8* s = GB_TextFrame;
-	u16* c = GB_TextColor;
-	u16 cc, ccc;
-	u8* s2;
-	const u8* f = FONT;
-	u16 bg = GB_TextBgColor;
+       u8 ch;
+       int line, col, pix;
+       u8* s = GB_TextFrame;
+       u16* c = GB_TextColor;
+       u16 cc, ccc;
+       u8* s2;
+       const u8* f = FONT;
+       u16 bg = GB_TextBgColor;
+       int rep = WIDTH / (GB_MSG_WIDTH*FONTH);
+       int rem = WIDTH % (GB_MSG_WIDTH*FONTH);
 
 	// start sending image data
 	DispStartImg(0, EMU_LCD_WIDTH, 0, EMU_LCD_HEIGHT);
@@ -141,31 +143,38 @@ void GB_TextUpdate()
 	// rows
 	for (line = 0; line < EMU_LCD_HEIGHT;)
 	{
-		cc = *c; // color of the row
-		s2 = s; // start of text row
+               cc = *c; // color of the row
+               s2 = s; // start of text row
+               int acc = 0;
 
-		// columns of text row
-		if (line < GB_MSG_LINES)
-		{
-			for (col = 0; col < GB_MSG_WIDTH; col++)
-			{
-				// get character
-				ch = *s2++;
+               // columns of text row
+               if (line < GB_MSG_LINES)
+               {
+                       for (col = 0; col < GB_MSG_WIDTH; col++)
+                       {
+                               // get character
+                               ch = *s2++;
 
-				// get font pixels
-				ch = f[ch];
+                               // get font pixels
+                               ch = f[ch];
 
-				// draw pixels
-				for (pix = 8; pix > 0; pix--)
-				{
-					// send color of the pixel (or black color of the background)
-					ccc = ((ch & 0x80) != 0) ? cc : bg;
-					DispSendImg2(ccc);
-					DispSendImg2(ccc);
-					ch <<= 1;
-				}
-			}
-		}
+                               // draw pixels
+                               for (pix = 8; pix > 0; pix--)
+                               {
+                                       // send color of the pixel (or black color of the background)
+                                       ccc = ((ch & 0x80) != 0) ? cc : bg;
+                                       int n = rep;
+                                       acc += rem;
+                                       if (acc >= GB_MSG_WIDTH*FONTH)
+                                       {
+                                               n++;
+                                               acc -= GB_MSG_WIDTH*FONTH;
+                                       }
+                                       for (; n > 0; n--) DispSendImg2(ccc);
+                                       ch <<= 1;
+                               }
+                       }
+               }
 
 		// columns of empty row
 		else

--- a/PicoPad/EMU/GBC/src/emu_gb_msg.h
+++ b/PicoPad/EMU/GBC/src/emu_gb_msg.h
@@ -14,7 +14,7 @@
 //	This source code is freely available for any purpose, including commercial.
 //	It is possible to take and modify the code or parts of it, without restriction.
 
-#define GB_MSG_WIDTH	(WIDTH/(2*8))	// message text width of window (1 character = 16 pixels width; = 20)
+#define GB_MSG_WIDTH    (WIDTH*2/(3*8))   // message text width (1 character = 12 pixels width)
 #define GB_MSG_HEIGHT	11		// message text height of window, 4 rows 2*height, 7 rows 1*height
 #define GB_MSG_BTMLINE	(4*FONTH*2)	// bottom line to start 1*height rows
 #define GB_MSG_LINES	(4*FONTH*2 + 7*FONTH) // height of message windows in graphics lines

--- a/_lib/emu/GB/emu_gb_msg.c
+++ b/_lib/emu/GB/emu_gb_msg.c
@@ -16,7 +16,7 @@
 
 // >>> Keep tables and functions in RAM (without "const") for faster access.
 
-#define EMU_LCD_WIDTH	320	// LCD display width
+#define EMU_LCD_WIDTH   WIDTH	// LCD display width
 #define EMU_LCD_HEIGHT	240	// LCD display height
 
 // text screen buffer (only characters; 160 bytes)
@@ -125,14 +125,16 @@ void GB_TextPrintCenter(const char* txt)
 // update text screen on display (called from the GB_LCDRedraw function, do not call it directly)
 void GB_TextUpdate()
 {
-	u8 ch;
-	int line, col, pix;
-	u8* s = GB_TextFrame;
-	u16* c = GB_TextColor;
-	u16 cc, ccc;
-	u8* s2;
-	const u8* f = FontBold8x16;
-	u16 bg = GB_TextBgColor;
+       u8 ch;
+       int line, col, pix;
+       u8* s = GB_TextFrame;
+       u16* c = GB_TextColor;
+       u16 cc, ccc;
+       u8* s2;
+       const u8* f = FontBold8x16;
+       u16 bg = GB_TextBgColor;
+       int rep = WIDTH / (GB_MSG_WIDTH*FONTH);
+       int rem = WIDTH % (GB_MSG_WIDTH*FONTH);
 
 	// do not screenshot this screen
 	Bool oldscreenshot = DoEmuScreenShot;
@@ -144,28 +146,35 @@ void GB_TextUpdate()
 	// rows
 	for (line = 0; line < EMU_LCD_HEIGHT;)
 	{
-		cc = *c; // color of the row
-		s2 = s; // start of text row
+               cc = *c; // color of the row
+               s2 = s; // start of text row
+               int acc = 0;
 
-		// columns
-		for (col = 0; col < GB_MSG_WIDTH; col++)
-		{
-			// get character
-			ch = *s2++;
+               // columns
+               for (col = 0; col < GB_MSG_WIDTH; col++)
+               {
+                       // get character
+                       ch = *s2++;
 
-			// get font pixels
-			ch = f[ch];
+                       // get font pixels
+                       ch = f[ch];
 
-			// draw pixels
-			for (pix = 8; pix > 0; pix--)
-			{
-				// send color of the pixel (or black color of the background)
-				ccc = ((ch & 0x80) != 0) ? cc : bg;
-				DispSendImg2(ccc);
-				DispSendImg2(ccc);
-				ch <<= 1;
-			}
-		}
+                       // draw pixels
+                       for (pix = 8; pix > 0; pix--)
+                       {
+                               // send color of the pixel (or black color of the background)
+                               ccc = ((ch & 0x80) != 0) ? cc : bg;
+                               int n = rep;
+                               acc += rem;
+                               if (acc >= GB_MSG_WIDTH*FONTH)
+                               {
+                                       n++;
+                                       acc -= GB_MSG_WIDTH*FONTH;
+                               }
+                               for (; n > 0; n--) DispSendImg2(ccc);
+                               ch <<= 1;
+                       }
+               }
 
 		// increase line
 		line++;

--- a/_lib/emu/GB/emu_gb_msg.h
+++ b/_lib/emu/GB/emu_gb_msg.h
@@ -18,7 +18,7 @@
 
 //	SelFont8x16();
 
-#define GB_MSG_WIDTH	(WIDTH/(2*8))	// message text width of window (1 character = 16 pixels width; = 20)
+#define GB_MSG_WIDTH    (WIDTH*2/(3*8))   // message text width (1 character = 12 pixels width)
 #define GB_MSG_HEIGHT	((HEIGHT+2*16-1)/(2*16)) // message text height of window (1 character = 32 lined height; = 8)
 
 // text screen buffer (only characters; 160 bytes)


### PR DESCRIPTION
## Summary
- Reference display width macros in GB message rendering instead of fixed 320px.
- Use computed horizontal scale factor to draw message text, replacing fixed pixel duplication.
- Derive GB_MSG_WIDTH from display width with 3/2 scaling for 12px characters.

## Testing
- `gcc -c _lib/emu/GB/emu_gb_msg.c -I _lib/emu/GB -I .` *(fails: unknown type name 'u8')*
- `gcc -c PicoPad/EMU/GBC/src/emu_gb_msg.c -I PicoPad/EMU/GBC/src -I .` *(fails: include expects "FILENAME" or <FILENAME>)*

------
https://chatgpt.com/codex/tasks/task_e_68994f699d708323b4af0cb7cc8cb997