### PR TITLE
Improve LCD scaling

### DIFF
--- a/PicoPad/EMU/GBC/src/main.cpp
+++ b/PicoPad/EMU/GBC/src/main.cpp
@@ -815,32 +815,27 @@ void FASTCODE NOFLASH(core1DrawFrame)()
 		s = &gbContext.framebuf[rinx*LCD_WIDTH];
 
 #if DEB_FPS			// debug display FPS
-		if (y < 16)
-		{
-			u16* s2 = &buf[16*y];
-			for (x = LCD_WIDTH; x > 0; x--)
-			{
-				if (x <= 8)
-				{
-					DispSendImg2(*s2++);
-					DispSendImg2(*s2++);
-				}
-				else
-				{
-					c = *s++;
-					DispSendImg2(c);
-					DispSendImg2(c);
-				}
-			}
-		}
-		else
+               if (y < 16)
+               {
+                       u16* s2 = &buf[16*y];
+                       for (x = 0; x < WIDTH; x++)
+                       {
+                               int xs2 = x * LCD_WIDTH / WIDTH;
+                               if (x < 16)
+                                       c = s2[x];
+                               else
+                                       c = s[xs2];
+                               DispSendImg2(c);
+                       }
+               }
+               else
 #endif
-		for (x = LCD_WIDTH; x > 0; x--)
-		{
-			c = *s++;
-			DispSendImg2(c);
-			DispSendImg2(c);
-		}
+               for (x = 0; x < WIDTH; x++)
+               {
+                       int xs2 = x * LCD_WIDTH / WIDTH;
+                       c = s[xs2];
+                       DispSendImg2(c);
+               }
 
 		// next source Y
 		// Check case: y = 239, old ys = 239*144/240 = 143, new ys2 = 240*144/240 = 144, it is OK


### PR DESCRIPTION
## Summary
- Rework GBC display loop to derive source index per pixel using LCD_WIDTH/ WIDTH ratio and transmit each pixel once

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68994f789ad48323909b83b3d0ae287b