### PR TITLE
Configure ST7789 display for GBC emulator

### DIFF
--- a/PicoPad/EMU/GBC/config.h
+++ b/PicoPad/EMU/GBC/config.h
@@ -13,49 +13,22 @@
 // to change from the default configuration in config_def.h.
 // *********
 
-#if USE_PICOPADHSTX		// use PicoPadHSTX device configuration
-#define USE_DISPHSTXMINI	1	// 1=use HSTX Display Mini driver
-#define USE_DISPHSTX		0	// 1=use HSTX Display driver
-//#define DISPHSTX_DISP_SEL	-1	// >=0 GPIO pin with display selection switch, -1=do not use display selection switch
-#define DISPHSTX_USE_DVI	1	// 1=use DVI (HDMI) support (DVI requires about 15 KB of RAM)
-#define DISPHSTX_USE_VGA	1	// 1=use VGA support (VGA requires about 30 KB of RAM)
+// Disable high-speed digital display outputs
+#define USE_DISPHSTXMINI        0       // 0=do not use HSTX Display Mini driver
+#define USE_DISPHSTX            0       // 0=do not use HSTX Display driver
+#define DISPHSTX_USE_DVI        0       // 0=disable DVI (HDMI) support
+#define DISPHSTX_USE_VGA        0       // 0=disable VGA support
 
-#define USE_DISPHSTXMINI_VMODE	5	// DispHstxMini videomode (default 1; data must be DISPHSTX_VGA_MASK masked in VGA case if only FrameBuf is used)
-					//	1=320x240/16bit, FrameBuf+DispBuf, sys_clock=126 MHz
-					//	2=320x240/16bit, FrameBuf+DispBuf, sys_clock=252 MHz
-					//	3=320x240/16bit (borders 2x46 pixels), FrameBuf+DispBuf, sys_clock variable, clocked from USB 144 MHz
-					//	4=320x240/16bit (borders 2x46 pixels), only FrameBuf, sys_clock variable, clocked from USB 144 MHz
-					//	5=320x144/16bit (borders 2x46 pixels), only FrameBuf, sys_clock variable, clocked from USB 144 MHz
-					//	6=360x240/16bit, only FrameBuf, sys_clock variable, clocked from USB 144 MHz
+// Configure built-in ST7789 LCD
+#define USE_ST7789              1       // 1=use ST7789 display driver
+#define WIDTH                   240     // display width
+#define HEIGHT                  240     // display height
 
-#define USE_DISPHSTX_VMODE	4	// DispHstx videomode (default 1)
-					//	0=custom
-					//	1=320x240/16 FrameBuf+DispBuf, slow (sys_clock=126 MHz, detected as 640x480@60)
-					//	2=320x240/16 FrameBuf+DispBuf, fast (sys_clock=252 MHz, detected as 640x480@60)
-					//	3=320x240/16 only FrameBuf, slow (sys_clock=126 MHz, detected as 640x480@60)
-					//	4=320x240/16 only FrameBuf, fast (sys_clock=252 MHz, detected as 640x480@60)
-					//	5=400x300/16 (sys_clock=200 MHz, detected as 800x600@60)
-					//	6=512x384/16 (sys_clock=324 MHz, detected as 1024x768@60Hz, sys_clock may not work on some Pico2s)
-					//	7=532x400/16 (sys_clock=210 MHz, detected as 720x400@70, can be unreliable on some monitors)
-					//	8=640x350/16 (sys_clock=252 MHz, detected as 640x350@70)
-					//	9=640x480/8 slow (sys_clock=126 MHz, detected as 640x480@60)
-					//	10=640x480/8 fast (sys_clock=252 MHz, detected as 640x480@60)
-					//	11=800x600/6 (sys_clock=200 MHz, detected as 800x600@60)
-					//	12=1024x768/4 (sys_clock=324 MHz, detected as 1024x768@60Hz, sys_clock may not work on some Pico2s)
-#define USE_FRAMEBUF		1		// do not use pre-defined Frame buffer
-#else // USE_PICOPADHSTX
-#define USE_FRAMEBUF		0		// do not use pre-defined Frame buffer
-#endif // USE_PICOPADHSTX
-
-#if USE_PICOPADHSTX && USE_DISPHSTXMINI && (USE_DISPHSTXMINI_VMODE == 5) // use PicoPadHSTX device configuration
-#define FONT		FontBold8x8	// default system font
-#define FONTW		8		// width of system font
-#define FONTH		8		// height of system font
-#else // USE_PICOPADHSTX
-#define FONT		FontBold8x16	// default system font
-#define FONTW		8		// width of system font
-#define FONTH		16		// height of system font
-#endif // USE_PICOPADHSTX
+// Frame buffer and font settings
+#define USE_FRAMEBUF            0               // do not use pre-defined Frame buffer
+#define FONT                    FontBold8x16    // default system font
+#define FONTW                   8               // width of system font
+#define FONTH                   16              // height of system font
 
 
 //#define USE_DRAW_STDIO	0		// use DRAW stdio (DrawPrint function)


### PR DESCRIPTION
## Summary
- disable HSTX display drivers and VGA/DVI support
- enable ST7789 driver with 240x240 resolution for the GBC emulator

## Testing
- `make` *(fails: No targets specified and no makefile found)*
- `make -C PicoPad/EMU/GBC` *(fails: missing `_devices//_makefile.inc`)*

------
https://chatgpt.com/codex/tasks/task_e_68994f876e8483239d9dbdf68659fb22