### PR TITLE
Enable stereo PWM audio for GBC project

### DIFF
--- a/PicoPad/EMU/GBC/config.h
+++ b/PicoPad/EMU/GBC/config.h
@@ -69,7 +69,9 @@
 //#define GB_RAM_BASE		((u8*)FrameBuf)	// RAM base address (declared as u8*)
 //#define GB_RAM_SIZE		(200*1024)	// RAM size in number of bytes
 
-#define USE_PWMSND		0		// use PWM sound output; set 1.. = number of channels (lib_pwmsnd.c, lib_pwmsnd.h)
+#define USE_PWMSND              2               // use PWM sound output; set 1.. = number of channels (lib_pwmsnd.c, lib_pwmsnd.h)
+#define PWMSND_GPIO             15              // PWM sound output GPIO pin (left channel)
+#define PWMSND_GPIO_R           14              // PWM sound output GPIO pin (right channel; -1 = not used, only single channel is used)
 //#define USE_ORIGSDK		1		// include interface of original-SDK
 //#define EMU_DEBUG_SYNC	1		// 1 = debug measure time synchronization
 //#define USE_SCREENSHOT	1		// use screen shots


### PR DESCRIPTION
## Summary
- enable PWM audio with two channels
- map left audio to GPIO15 and right audio to GPIO14

## Testing
- `./c.sh picopad10` *(failed: arm-none-eabi-gcc: No such file or directory)*
- `sudo apt-get update` *(failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689aa321d69c8323a49a9f9df2867485