### PR TITLE
Fix GB menu duplication on 240x240 displays

### DIFF
--- a/PicoPad/EMU/GBC/src/emu_gb_menu.c
+++ b/PicoPad/EMU/GBC/src/emu_gb_menu.c
@@ -434,11 +434,8 @@ void GB_MenuDraw()
 	// 6) Up/Dn load/save
 	GB_TextPrint("\n\rLe/Ri load/save");
 
-	// 7)
-	GB_TextY++;
-
-	// set info color
-	GB_TextSetCol(COL_LTGRAY);
+        // set info color
+        GB_TextSetCol(COL_LTGRAY);
 
 	// 8) DEV=GBC MBC=1 PAL=23
 	GB_TextPrint("\n\rDEV=");

--- a/PicoPad/EMU/GBC/src/emu_gb_msg.c
+++ b/PicoPad/EMU/GBC/src/emu_gb_msg.c
@@ -137,72 +137,73 @@ void GB_TextUpdate()
        int rep = WIDTH / (GB_MSG_WIDTH*FONTH);
        int rem = WIDTH % (GB_MSG_WIDTH*FONTH);
 
-	// start sending image data
-	DispStartImg(0, EMU_LCD_WIDTH, 0, EMU_LCD_HEIGHT);
+       // number of lines to draw
+       int lines = EMU_LCD_HEIGHT;
+       if (GB_MSG_LINES < lines) lines = GB_MSG_LINES;
 
-	// rows
-	for (line = 0; line < EMU_LCD_HEIGHT;)
-	{
+        // start sending only the required number of lines
+        DispStartImg(0, EMU_LCD_WIDTH, 0, lines);
+
+        // rows with text
+        for (line = 0; line < lines;)
+        {
                cc = *c; // color of the row
                s2 = s; // start of text row
                int acc = 0;
 
                // columns of text row
-               if (line < GB_MSG_LINES)
+               for (col = 0; col < GB_MSG_WIDTH; col++)
                {
-                       for (col = 0; col < GB_MSG_WIDTH; col++)
+                       // get character
+                       ch = *s2++;
+
+                       // get font pixels
+                       ch = f[ch];
+
+                       // draw pixels
+                       for (pix = 8; pix > 0; pix--)
                        {
-                               // get character
-                               ch = *s2++;
-
-                               // get font pixels
-                               ch = f[ch];
-
-                               // draw pixels
-                               for (pix = 8; pix > 0; pix--)
+                               // send color of the pixel (or background color)
+                               ccc = ((ch & 0x80) != 0) ? cc : bg;
+                               int n = rep;
+                               acc += rem;
+                               if (acc >= GB_MSG_WIDTH*FONTH)
                                {
-                                       // send color of the pixel (or black color of the background)
-                                       ccc = ((ch & 0x80) != 0) ? cc : bg;
-                                       int n = rep;
-                                       acc += rem;
-                                       if (acc >= GB_MSG_WIDTH*FONTH)
-                                       {
-                                               n++;
-                                               acc -= GB_MSG_WIDTH*FONTH;
-                                       }
-                                       for (; n > 0; n--) DispSendImg2(ccc);
-                                       ch <<= 1;
+                                       n++;
+                                       acc -= GB_MSG_WIDTH*FONTH;
                                }
+                               for (; n > 0; n--) DispSendImg2(ccc);
+                               ch <<= 1;
                        }
                }
 
-		// columns of empty row
-		else
-		{
-			for (col = EMU_LCD_WIDTH; col > 0; col--) DispSendImg2(COL_BLACK);
-		}
+                // increase line
+                line++;
 
-		// increase line
-		line++;
+                // odd line - do nothing (repeat)
+                if (((line & 1) == 0) || (line >= GB_MSG_BTMLINE))
+                {
+                        // shift to next line of the font
+                        f += 256;
 
-		// odd line - do nothing (repeat)
-		if (((line & 1) == 0) || (line >= GB_MSG_BTMLINE))
-		{
-			// shift to next line of the font
-			f += 256;
+                        // next row after 32 lines
+                        if (((line & (2*FONTH-1)) == 0) || (((line & (FONTH-1)) == 0) && (line >= GB_MSG_BTMLINE)))
+                        {
+                                c++; // color of the row
+                                s = s2; // start of text row
+                                f = FONT; // font
+                        }
+                }
+        }
 
-			// next row after 32 lines
-			if (((line & (2*FONTH-1)) == 0) || (((line & (FONTH-1)) == 0) && (line >= GB_MSG_BTMLINE)))
-			{
-				c++; // color of the row
-				s = s2; // start of text row
-				f = FONT; // font
-			}
-		}
-	}
+       // fill remaining lines with background color
+       for (; line < lines; line++)
+       {
+               for (col = EMU_LCD_WIDTH; col > 0; col--) DispSendImg2(bg);
+       }
 
-	// stop sending data
-	DispStopImg();
+        // stop sending data
+        DispStopImg();
 }
 
 /*

--- a/_lib/emu/GB/emu_gb_msg.c
+++ b/_lib/emu/GB/emu_gb_msg.c
@@ -17,7 +17,7 @@
 // >>> Keep tables and functions in RAM (without "const") for faster access.
 
 #define EMU_LCD_WIDTH   WIDTH	// LCD display width
-#define EMU_LCD_HEIGHT	240	// LCD display height
+#define EMU_LCD_HEIGHT  HEIGHT   // LCD display height
 
 // text screen buffer (only characters; 160 bytes)
 u8 GB_TextFrame[GB_MSG_WIDTH*GB_MSG_HEIGHT];
@@ -131,7 +131,7 @@ void GB_TextUpdate()
        u16* c = GB_TextColor;
        u16 cc, ccc;
        u8* s2;
-       const u8* f = FontBold8x16;
+       const u8* f = FONT;
        u16 bg = GB_TextBgColor;
        int rep = WIDTH / (GB_MSG_WIDTH*FONTH);
        int rem = WIDTH % (GB_MSG_WIDTH*FONTH);
@@ -140,11 +140,15 @@ void GB_TextUpdate()
 	Bool oldscreenshot = DoEmuScreenShot;
 	DoEmuScreenShot = False;
 
-	// start sending image data
-	DispStartImg(0, EMU_LCD_WIDTH, 0, EMU_LCD_HEIGHT);
+       // number of lines to draw
+       int lines = EMU_LCD_HEIGHT;
+       if (GB_MSG_LINES < lines) lines = GB_MSG_LINES;
 
-	// rows
-	for (line = 0; line < EMU_LCD_HEIGHT;)
+       // start sending image data
+       DispStartImg(0, EMU_LCD_WIDTH, 0, lines);
+
+       // rows
+       for (line = 0; line < lines;)
 	{
                cc = *c; // color of the row
                s2 = s; // start of text row
@@ -180,20 +184,27 @@ void GB_TextUpdate()
 		line++;
 
 		// odd line - do nothing (repeat)
-		if (((line & 1) == 0) || (line >= 7*32))
+                if (((line & 1) == 0) || (line >= GB_MSG_BTMLINE))
 		{
 			// shift to next line of the font
 			f += 256;
 
 			// next row after 32 lines
-			if ((line & 0x1f) == 0)
+                        if (((line & (2*FONTH-1)) == 0) || (((line & (FONTH-1)) == 0) && (line >= GB_MSG_BTMLINE)))
 			{
 				c++; // color of the row
 				s = s2; // start of text row
-				f = FontBold8x16; // font
+                                f = FONT; // font
 			}
 		}
 	}
+
+
+       // fill remaining lines with background color
+       for (; line < lines; line++)
+       {
+               for (col = EMU_LCD_WIDTH; col > 0; col--) DispSendImg2(bg);
+       }
 
 	// stop sending data
 	DispStopImg();

--- a/_lib/emu/GB/emu_gb_msg.h
+++ b/_lib/emu/GB/emu_gb_msg.h
@@ -19,7 +19,9 @@
 //	SelFont8x16();
 
 #define GB_MSG_WIDTH    (WIDTH*2/(3*8))   // message text width (1 character = 12 pixels width)
-#define GB_MSG_HEIGHT	((HEIGHT+2*16-1)/(2*16)) // message text height of window (1 character = 32 lined height; = 8)
+#define GB_MSG_HEIGHT   11              // message text height of window, 4 rows 2*height, 7 rows 1*height
+#define GB_MSG_BTMLINE  (4*FONTH*2)     // bottom line to start 1*height rows
+#define GB_MSG_LINES    (4*FONTH*2 + 7*FONTH) // height of message window in graphics lines
 
 // text screen buffer (only characters; 160 bytes)
 extern u8 GB_TextFrame[GB_MSG_WIDTH*GB_MSG_HEIGHT];


### PR DESCRIPTION
## Summary
- define explicit message window dimensions for 240x240 panels
- limit GB_TextUpdate to valid message lines and pad the rest with background

## Testing
- `make -n` *(fails: No targets specified and no makefile found)*
- `cd PicoPad/EMU/GBC && ./c.sh` *(fails: arm-none-eabi-gcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689bc77086e883239e15cf20636e0ca6