### PR TITLE
Fix GBC menu text scaling to use full screen

### DIFF
--- a/PicoPad/EMU/GBC/src/emu_gb_menu.c
+++ b/PicoPad/EMU/GBC/src/emu_gb_menu.c
@@ -487,9 +487,10 @@ void GB_MenuDraw()
 	GB_TextSetCol(COL_MAGENTA);
 	GB_PrepSaveFile(GB_MenuSlot); // prepare save filename (0..9, -1=default)
 	i = 0;
-	if (SaveNameLen > GB_MSG_WIDTH) i = SaveNameLen - GB_MSG_WIDTH;
-	GB_TextPrint(&HomePath[i]);
-	GB_UnprepSaveFile(); // unprepare save filename
+       if (SaveNameLen > GB_MSG_WIDTH) i = SaveNameLen - GB_MSG_WIDTH;
+       GB_TextPrint(&HomePath[i]);
+       GB_TextPrintNL(1);
+       GB_UnprepSaveFile(); // unprepare save filename
 }
 
 // display emulator menu (return True to continue emulation)

--- a/PicoPad/EMU/GBC/src/emu_gb_msg.c
+++ b/PicoPad/EMU/GBC/src/emu_gb_msg.c
@@ -134,8 +134,8 @@ void GB_TextUpdate()
        u8* s2;
        const u8* f = FONT;
        u16 bg = GB_TextBgColor;
-       int rep = WIDTH / (GB_MSG_WIDTH*FONTH);
-       int rem = WIDTH % (GB_MSG_WIDTH*FONTH);
+       int rep = WIDTH / (GB_MSG_WIDTH*FONTW);
+       int rem = WIDTH % (GB_MSG_WIDTH*FONTW);
 
 	// start sending image data
 	DispStartImg(0, EMU_LCD_WIDTH, 0, EMU_LCD_HEIGHT);
@@ -148,58 +148,45 @@ void GB_TextUpdate()
                int acc = 0;
 
                // columns of text row
-               if (line < GB_MSG_LINES)
+               for (col = 0; col < GB_MSG_WIDTH; col++)
                {
-                       for (col = 0; col < GB_MSG_WIDTH; col++)
+                       // get character
+                       ch = *s2++;
+
+                       // get font pixels
+                       ch = f[ch];
+
+                       // draw pixels
+                       for (pix = 8; pix > 0; pix--)
                        {
-                               // get character
-                               ch = *s2++;
-
-                               // get font pixels
-                               ch = f[ch];
-
-                               // draw pixels
-                               for (pix = 8; pix > 0; pix--)
+                               // send color of the pixel (or black color of the background)
+                               ccc = ((ch & 0x80) != 0) ? cc : bg;
+                               int n = rep;
+                               acc += rem;
+                               if (acc >= GB_MSG_WIDTH*FONTW)
                                {
-                                       // send color of the pixel (or black color of the background)
-                                       ccc = ((ch & 0x80) != 0) ? cc : bg;
-                                       int n = rep;
-                                       acc += rem;
-                                       if (acc >= GB_MSG_WIDTH*FONTH)
-                                       {
-                                               n++;
-                                               acc -= GB_MSG_WIDTH*FONTH;
-                                       }
-                                       for (; n > 0; n--) DispSendImg2(ccc);
-                                       ch <<= 1;
+                                       n++;
+                                       acc -= GB_MSG_WIDTH*FONTW;
                                }
+                               for (; n > 0; n--) DispSendImg2(ccc);
+                               ch <<= 1;
                        }
                }
 
-		// columns of empty row
-		else
-		{
-			for (col = EMU_LCD_WIDTH; col > 0; col--) DispSendImg2(COL_BLACK);
-		}
+               // increase line
+               line++;
 
-		// increase line
-		line++;
+               // shift to next line of the font
+               f += 256;
 
-		// odd line - do nothing (repeat)
-		if (((line & 1) == 0) || (line >= GB_MSG_BTMLINE))
-		{
-			// shift to next line of the font
-			f += 256;
-
-			// next row after 32 lines
-			if (((line & (2*FONTH-1)) == 0) || (((line & (FONTH-1)) == 0) && (line >= GB_MSG_BTMLINE)))
-			{
-				c++; // color of the row
-				s = s2; // start of text row
-				f = FONT; // font
-			}
-		}
-	}
+               // next row after FONTH lines
+               if ((line & (FONTH-1)) == 0)
+               {
+                       c++;      // color of the row
+                       s = s2;   // start of text row
+                       f = FONT; // reset font pointer
+               }
+       }
 
 	// stop sending data
 	DispStopImg();

--- a/PicoPad/EMU/GBC/src/emu_gb_msg.h
+++ b/PicoPad/EMU/GBC/src/emu_gb_msg.h
@@ -15,9 +15,7 @@
 //	It is possible to take and modify the code or parts of it, without restriction.
 
 #define GB_MSG_WIDTH    (WIDTH*2/(3*8))   // message text width (1 character = 12 pixels width)
-#define GB_MSG_HEIGHT	11		// message text height of window, 4 rows 2*height, 7 rows 1*height
-#define GB_MSG_BTMLINE	(4*FONTH*2)	// bottom line to start 1*height rows
-#define GB_MSG_LINES	(4*FONTH*2 + 7*FONTH) // height of message windows in graphics lines
+#define GB_MSG_HEIGHT   (HEIGHT / FONTH)  // message text height of window
 
 // text screen buffer (only characters; 160 bytes)
 extern u8 GB_TextFrame[GB_MSG_WIDTH*GB_MSG_HEIGHT];

--- a/_lib/emu/GB/emu_gb_msg.c
+++ b/_lib/emu/GB/emu_gb_msg.c
@@ -133,8 +133,8 @@ void GB_TextUpdate()
        u8* s2;
        const u8* f = FontBold8x16;
        u16 bg = GB_TextBgColor;
-       int rep = WIDTH / (GB_MSG_WIDTH*FONTH);
-       int rem = WIDTH % (GB_MSG_WIDTH*FONTH);
+       int rep = WIDTH / (GB_MSG_WIDTH*FONTW);
+       int rem = WIDTH % (GB_MSG_WIDTH*FONTW);
 
 	// do not screenshot this screen
 	Bool oldscreenshot = DoEmuScreenShot;
@@ -166,34 +166,30 @@ void GB_TextUpdate()
                                ccc = ((ch & 0x80) != 0) ? cc : bg;
                                int n = rep;
                                acc += rem;
-                               if (acc >= GB_MSG_WIDTH*FONTH)
+                               if (acc >= GB_MSG_WIDTH*FONTW)
                                {
                                        n++;
-                                       acc -= GB_MSG_WIDTH*FONTH;
+                                       acc -= GB_MSG_WIDTH*FONTW;
                                }
                                for (; n > 0; n--) DispSendImg2(ccc);
                                ch <<= 1;
                        }
                }
 
-		// increase line
-		line++;
+               // increase line
+               line++;
 
-		// odd line - do nothing (repeat)
-		if (((line & 1) == 0) || (line >= 7*32))
-		{
-			// shift to next line of the font
-			f += 256;
+               // shift to next line of the font
+               f += 256;
 
-			// next row after 32 lines
-			if ((line & 0x1f) == 0)
-			{
-				c++; // color of the row
-				s = s2; // start of text row
-				f = FontBold8x16; // font
-			}
-		}
-	}
+               // next row after FONTH lines
+               if ((line & (FONTH-1)) == 0)
+               {
+                       c++;      // color of the row
+                       s = s2;   // start of text row
+                       f = FontBold8x16; // reset font pointer
+               }
+       }
 
 	// stop sending data
 	DispStopImg();

--- a/_lib/emu/GB/emu_gb_msg.h
+++ b/_lib/emu/GB/emu_gb_msg.h
@@ -19,7 +19,7 @@
 //	SelFont8x16();
 
 #define GB_MSG_WIDTH    (WIDTH*2/(3*8))   // message text width (1 character = 12 pixels width)
-#define GB_MSG_HEIGHT	((HEIGHT+2*16-1)/(2*16)) // message text height of window (1 character = 32 lined height; = 8)
+#define GB_MSG_HEIGHT   (HEIGHT / FONTH)  // message text height of window
 
 // text screen buffer (only characters; 160 bytes)
 extern u8 GB_TextFrame[GB_MSG_WIDTH*GB_MSG_HEIGHT];


### PR DESCRIPTION
## Summary
- fix horizontal scaling in GB_TextUpdate by basing pixel replication on font width
- remove vertical duplication logic so menu uses full screen height
- flush leftover characters by adding newline after save path

## Testing
- `make -C PicoPad/EMU/GBC` *(fails: No rule to make target '../../../_devices//_makefile.inc')*

------
https://chatgpt.com/codex/tasks/task_e_689c130b8094832395dfbd31e272f522