### PR TITLE
Reduce GB emulator menu font size

### DIFF
--- a/PicoPad/EMU/GBC/src/emu_gb_msg.c
+++ b/PicoPad/EMU/GBC/src/emu_gb_msg.c
@@ -19,7 +19,7 @@
 #define EMU_LCD_WIDTH   WIDTH	// LCD display width
 #define EMU_LCD_HEIGHT	HEIGHT	// LCD display height
 
-// text screen buffer (only characters; 160 bytes)
+// text screen buffer (only characters; ~315 bytes on 240x240)
 u8 GB_TextFrame[GB_MSG_WIDTH*GB_MSG_HEIGHT];
 
 // colors of rows

--- a/PicoPad/EMU/GBC/src/emu_gb_msg.h
+++ b/PicoPad/EMU/GBC/src/emu_gb_msg.h
@@ -14,10 +14,10 @@
 //	This source code is freely available for any purpose, including commercial.
 //	It is possible to take and modify the code or parts of it, without restriction.
 
-#define GB_MSG_WIDTH    (WIDTH*2/(3*8))   // message text width (1 character = 12 pixels width)
+#define GB_MSG_WIDTH    (WIDTH*21/240)    // message text width (~5% smaller, ~11 px per char)
 #define GB_MSG_HEIGHT   (HEIGHT / FONTH)  // message text height of window
 
-// text screen buffer (only characters; 160 bytes)
+// text screen buffer (only characters; ~315 bytes on 240x240)
 extern u8 GB_TextFrame[GB_MSG_WIDTH*GB_MSG_HEIGHT];
 
 // colors of rows

--- a/_lib/emu/GB/emu_gb_msg.c
+++ b/_lib/emu/GB/emu_gb_msg.c
@@ -19,7 +19,7 @@
 #define EMU_LCD_WIDTH   WIDTH	// LCD display width
 #define EMU_LCD_HEIGHT	240	// LCD display height
 
-// text screen buffer (only characters; 160 bytes)
+// text screen buffer (only characters; ~315 bytes on 240x240)
 u8 GB_TextFrame[GB_MSG_WIDTH*GB_MSG_HEIGHT];
 
 // colors of rows

--- a/_lib/emu/GB/emu_gb_msg.h
+++ b/_lib/emu/GB/emu_gb_msg.h
@@ -18,10 +18,10 @@
 
 //	SelFont8x16();
 
-#define GB_MSG_WIDTH    (WIDTH*2/(3*8))   // message text width (1 character = 12 pixels width)
+#define GB_MSG_WIDTH    (WIDTH*21/240)    // message text width (~5% smaller, ~11 px per char)
 #define GB_MSG_HEIGHT   (HEIGHT / FONTH)  // message text height of window
 
-// text screen buffer (only characters; 160 bytes)
+// text screen buffer (only characters; ~315 bytes on 240x240)
 extern u8 GB_TextFrame[GB_MSG_WIDTH*GB_MSG_HEIGHT];
 
 // colors of rows


### PR DESCRIPTION
## Summary
- shrink Game Boy emulator menu font width by ~5%
- correct text buffer comments for 240x240 display (~315 bytes)

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_689d1465b7a08323a03189c0279b27d8